### PR TITLE
Fix NoRender Nether Portals

### DIFF
--- a/src/main/java/net/aoba/module/modules/render/NoRender.java
+++ b/src/main/java/net/aoba/module/modules/render/NoRender.java
@@ -99,7 +99,7 @@ public class NoRender extends Module {
 	}
 
 	public boolean getNoPortalOverlay() {
-		return noPumpkinOverlay.getValue();
+		return noPortalOverlay.getValue();
 	}
 
 	public boolean getNoPowderSnowOverlay() {


### PR DESCRIPTION
Previously, the getter for the portal overlay setting referenced the pumpkin overlay field instead of the portal overlay field. Fixed by changing the getter to use the correct field.