### PR TITLE
Fixed crash when other mods access gamma options.

### DIFF
--- a/src/main/java/net/aoba/mixin/OptionsMixin.java
+++ b/src/main/java/net/aoba/mixin/OptionsMixin.java
@@ -60,6 +60,9 @@ public class OptionsMixin {
 		if (aoba == null)
 			return;
 
+		if(aoba.moduleManager == null || aoba.moduleManager.fullbright == null || aoba.moduleManager.xray == null)
+			return;
+
 		if (aoba.moduleManager.fullbright.state.getValue() || aoba.moduleManager.xray.state.getValue()) {
 			cir.setReturnValue(fullbrightOption);
 		}


### PR DESCRIPTION
On initialization, mods accessing the Gamma options would crash the client as Aoba was not initialized yet.
Adding a null check fixes this issue.